### PR TITLE
adding explicit target and source for the maven compiler to build pro…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
                 <version>3.8.1</version>
                 <inherited>true</inherited>
                 <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Werror</arg>


### PR DESCRIPTION
…ject

build fails with error without setting this on my java version openjdk 21